### PR TITLE
Update index.html

### DIFF
--- a/protocols/wikipathways-app/index.html
+++ b/protocols/wikipathways-app/index.html
@@ -246,7 +246,8 @@
         <ul>
             <li>Load the <a href="https://raw.githubusercontent.com/cytoscape/cytoscape-tutorials/gh-pages/protocols/data/E-GEOD-68086">E-GEOD-68086</a> file under <highlight>File</highlight> menu, select <highlight>Import &rarr; Table from File....</highlight>.</li>
          <li>Under <highlight>Where to Import Table Data</highlight>, select <highlight>To selected networks only</highlight> and click the <b>Select All</b> button to select all of the networks in the <b>Network List</b>.</li>
-         <li>In the <highlight>Key Column for Network</highlight> drop-down, select the new <b>Ensembl</b> column.</li>
+	 <li>For the <highlight>Import Data as:</highlight> option, select the <b>Ensembl</b> column.</li>
+         <li>In the <highlight>Key Column for Network</highlight> drop-down, select the <b>Node Table columns</b>.</li>
          <li>In the <highlight>Preview</highlight> table, note that the <b>Gene ID</b> column is already selected as the key.</li>
         </ul>
         


### PR DESCRIPTION
Adding check for "import data as" @khanspers 

For some reason, when I load a pathway through the WikiPathways App, it always opens as an "Edge Table", not on the "Node Table". This also provided a conflict when wanting to load data, since I then cannot find the name of the 'Ensembl" column. I'm not sure if this is a bug, but I wanted to report this behavior. I'm currently using Cytoscape 3.9.0 (will update to 3.10.0 later today), on Linux, Ubuntu 18.04 . @AlexanderPico 